### PR TITLE
Add types

### DIFF
--- a/src/level1.py
+++ b/src/level1.py
@@ -1,7 +1,8 @@
 from mazemastery.api import *
 
-def solve():
-    while (True):
+
+def solve() -> None:
+    while True:
         i, j = get_pos()
         new_pos = (i, j + 1)
         set_pos(new_pos)

--- a/src/level2.py
+++ b/src/level2.py
@@ -1,7 +1,8 @@
 from mazemastery.api import *
 
-def solve():
-    while (not has_minotaur()):
+
+def solve() -> None:
+    while not has_minotaur():
         i, j = get_pos()
         new_pos = (i, j + 1)
         set_pos(new_pos)

--- a/src/level3.py
+++ b/src/level3.py
@@ -1,7 +1,8 @@
 from mazemastery.api import *
 
-def solve():
-    while (not has_minotaur()):
+
+def solve() -> None:
+    while not has_minotaur():
         put_blue_gem()
         for neighbor in get_neighbors():
             if not has_blue_gem(neighbor):

--- a/src/level4.py
+++ b/src/level4.py
@@ -1,6 +1,7 @@
 from mazemastery.api import *
 
-def solve():
+
+def solve() -> None:
     while not has_minotaur():
         put_blue_gem()
         found_neighbor = False

--- a/src/level5.py
+++ b/src/level5.py
@@ -1,6 +1,7 @@
 from mazemastery.api import *
 
-def solve():
+
+def solve() -> None:
     stack = [get_pos()]
     while not has_minotaur():
         put_blue_gem()

--- a/src/level6.py
+++ b/src/level6.py
@@ -1,7 +1,7 @@
 from mazemastery.api import *
 
 found_minotaur = False
-def solve():
+def solve() -> None:
     global found_minotaur
     put_blue_gem()
     for neighbor in get_neighbors():

--- a/src/mazemastery/api.py
+++ b/src/mazemastery/api.py
@@ -1,22 +1,25 @@
-import time
 import random
-from mazemastery.maze import create_maze, create_corridor, create_SAW
-from mazemastery.renderer import GUI
 import threading
+import time
+from typing import Callable
+
+from mazemastery.maze import create_corridor, create_maze, create_SAW
+from mazemastery.renderer import GUI
 from mazemastery.state import State
+from mazemastery.types import Coord
 
 
-def get_pos():
+def get_pos() -> Coord:
     state = State()
     return state.pos
 
 
-def minotaur():
+def minotaur() -> Coord:
     state = State()
     return state.minotaur_coords
 
 
-def set_pos(new_pos):
+def set_pos(new_pos: Coord) -> None:
     state = State()
     if state.dead:
         return
@@ -39,7 +42,7 @@ def set_pos(new_pos):
         time.sleep(state.renderer.delay / 1000)
 
 
-def put_blue_gem():
+def put_blue_gem() -> None:
     state = State()
     pos = state.pos
     if pos not in state.blue_gem_coords:
@@ -47,7 +50,7 @@ def put_blue_gem():
         state.blue_gem_coords.append(pos)
 
 
-def put_red_gem():
+def put_red_gem() -> None:
     state = State()
     pos = state.pos
     if pos not in state.red_gem_coords:
@@ -55,38 +58,38 @@ def put_red_gem():
         state.red_gem_coords.append(pos)
 
 
-def has_blue_gem(cell):
+def has_blue_gem(cell: Coord) -> bool:
     state = State()
     return cell in state.blue_gem_coords
 
 
-def has_red_gem(cell):
+def has_red_gem(cell: Coord) -> bool:
     state = State()
     return cell in state.red_gem_coords
 
 
-def has_minotaur():
+def has_minotaur() -> bool:
     state = State()
     return state.pos == state.minotaur_coords
 
 
-def is_neighbor(pos, neighbor):
+def is_neighbor(pos: Coord, neighbor: Coord) -> bool:
     state = State()
     return neighbor in state.maze[pos]
 
 
-def are_neighbors(pos1, pos2):
+def are_neighbors(pos1: Coord, pos2: Coord) -> bool:
     state = State()
     return pos2 in state.maze[pos1]
 
 
-def get_neighbors():
+def get_neighbors() -> list[Coord]:
     state = State()
     pos = state.pos
     return state.maze[pos]
 
 
-def run(level, solve, rows=10, cols=10, cell_size=50, delay=1000, seed=None):
+def run(level: int, solve: Callable[[], None], rows: int=10, cols: int=10, cell_size: int=50, delay: int=1000, seed: int | None=None) -> None:
     random.seed(seed)
     if level == 1:
         maze = create_corridor(cols)

--- a/src/mazemastery/debug_menu.py
+++ b/src/mazemastery/debug_menu.py
@@ -1,11 +1,14 @@
 import tkinter as tk
-from mazemastery.styles import Styles
+from typing import TYPE_CHECKING
+
 import mazemastery.api as api
 from mazemastery.state import State
+from mazemastery.styles import Styles
+from mazemastery.types import Renderer
 
 
 class DebugMenu:
-    def __init__(self, renderer):
+    def __init__(self, renderer: Renderer):
         # These buttons are used to modify the maze state in debug mode
         self.api_buttons = {
             "put_red_gem": tk.Button(
@@ -89,7 +92,7 @@ class DebugMenu:
 
         self.renderer = renderer
 
-    def update_menu(self):
+    def update_menu(self) -> None:
         """
         Beware - this can only be called after initialization of the renderer
         due to an ugly circular dependency between the renderer and the api.
@@ -119,17 +122,17 @@ class DebugMenu:
             for key, button in {**self.api_buttons, **self.nav_buttons}.items():
                 button.configure(state=tk.DISABLED, relief=tk.FLAT)
 
-    def handle_put_red_gem_button(self):
+    def handle_put_red_gem_button(self) -> None:
         api.put_red_gem()
         self.renderer.draw_gems()
         self.update_menu()
 
-    def handle_put_blue_gem_button(self):
+    def handle_put_blue_gem_button(self) -> None:
         api.put_blue_gem()
         self.renderer.draw_gems()
         self.update_menu()
 
-    def handle_debug_button(self):
+    def handle_debug_button(self) -> None:
         self.renderer.debug = not self.renderer.debug
         state = State()
         if self.renderer.debug:
@@ -139,7 +142,7 @@ class DebugMenu:
             self.renderer.canvas.delete("cloud")
         self.update_menu()
 
-    def handle_nav_button(self, dir):
+    def handle_nav_button(self, dir: tuple[int, int]) -> None:
         """
         We cannot use the api call 'set_pos' here because if otherwise the current
         thread will run into the while loop that only resolves once we leave

--- a/src/mazemastery/maze.py
+++ b/src/mazemastery/maze.py
@@ -1,8 +1,10 @@
-import random
 import math
+import random
+
+from mazemastery.types import Coord, Maze
 
 
-def randomize_neighbor_order(maze):
+def randomize_neighbor_order(maze: Maze) -> Maze:
     """
     Randomizes the order of neighbors of each cell in the maze to
     avoid users relying on a specific order.
@@ -13,17 +15,17 @@ def randomize_neighbor_order(maze):
     return maze
 
 
-def get_maze_size(maze):
+def get_maze_size(maze: Maze) -> tuple[int, int]:
     m = max(i for i, _ in maze.keys()) + 1  # Number of rows
     n = max(j for _, j in maze.keys()) + 1  # Number of columns
     return m, n
 
 
-def create_corridor(length):
+def create_corridor(length: int) -> Maze:
     """
     Generates a maze of length `length` that is a single path.
     """
-    maze = {}
+    maze: Maze = {}
     for j in range(1, length - 1):
         maze[(0, j)] = [(0, j + 1), (0, j - 1)]
     maze[(0, 0)] = [(0, 1)]
@@ -32,7 +34,7 @@ def create_corridor(length):
     return maze
 
 
-def create_SAW(rows, cols, temp=0.01):
+def create_SAW(rows: int, cols: int, temp: float=0.01) -> tuple[Maze, list[Coord]]:
     """
     Generates a maze of size `rows` x `cols` that contains a self-avoiding walk.
     """
@@ -68,7 +70,7 @@ def create_SAW(rows, cols, temp=0.01):
         counts = [z for (_, z) in neighbors_counts]
         probs = softmax(counts, temp=-temp)
         pos = weighted_choice(neighbors, probs)
-    maze = {(i, j): [] for i in range(rows) for j in range(cols)}
+    maze: Maze = {(i, j): [] for i in range(rows) for j in range(cols)}
     for i in range(1, len(path) - 1):
         maze[path[i]] = [path[i - 1], path[i + 1]]
     maze[path[0]] = [path[1]]
@@ -77,7 +79,7 @@ def create_SAW(rows, cols, temp=0.01):
     return maze, path
 
 
-def softmax(vals, temp=0.5):
+def softmax(vals: list[int], temp: float=0.5) -> list[float]:
     """
     Softmax function with temperature `temp`.
     """
@@ -88,12 +90,12 @@ def softmax(vals, temp=0.5):
     return [v / (sum_exp_vals) for v in exp_vals]
 
 
-def weighted_choice(choices, probs):
+def weighted_choice(choices: list[Coord], probs: list[float]) -> Coord: # Could be made generic
     """
     Chooses a random element from `choices` with probabilities `probs`.
     """
     r = random.uniform(0, 1)
-    total = 0
+    total = 0.0
     for c, p in zip(choices, probs):
         total += p
         if total > r:
@@ -101,7 +103,7 @@ def weighted_choice(choices, probs):
     return choices[-1]
 
 
-def count_neighbors_in_2x2_subgraph(maze, bi, bj):
+def count_neighbors_in_2x2_subgraph(maze: Maze, bi: int, bj: int) -> int:
     """
     Count number of neighbors within 2x2 subgraph whose North-West cell
     is (bi, bj).
@@ -114,7 +116,7 @@ def count_neighbors_in_2x2_subgraph(maze, bi, bj):
     return count
 
 
-def creates_2x2_hole(maze, c0, c1):
+def creates_2x2_hole(maze: Maze, c0: Coord, c1: Coord) -> bool:
     """
     Check if the removal of the wall between neighbor1 and neighbor2 creates a
     empty space of size at least 2x2 or larger.
@@ -150,7 +152,7 @@ def creates_2x2_hole(maze, c0, c1):
     return False
 
 
-def create_maze(rows, cols, start, p_remove=0.9):
+def create_maze(rows: int, cols: int, start: Coord, p_remove: float=0.9) -> Maze:
     """
     Performs randomized depth-first search to create a maze.
     """
@@ -159,18 +161,19 @@ def create_maze(rows, cols, start, p_remove=0.9):
     # A node is a 2-tupel (i, j) representing the row and column of a cell.
     # The list of neighbors of a node is the set of nodes that can be reached
     # from the node.
-    maze = {(i, j): [] for i in range(rows) for j in range(cols)}
-    prev = {(i, j): None for i in range(rows) for j in range(cols)}
+    maze: Maze = {(i, j): [] for i in range(rows) for j in range(cols)}
+    prev: dict[Coord, Coord | None] = {(i, j): None for i in range(rows) for j in range(cols)}
     stack = [start]
     visited = set()
     offsets = [(-1, 0), (0, -1), (0, 1), (1, 0)]
 
     while len(stack) > 0:
         current = stack.pop()
-        if prev[current]:
-            if prev[current] not in current:
-                maze[current].append(prev[current])
-                maze[prev[current]].append(current)
+        prev_current = prev[current]
+        if prev_current:
+            if prev_current not in current:
+                maze[current].append(prev_current)
+                maze[prev_current].append(current)
         visited.add(current)
         i, j = current
         neighbors = [(i + di, j + dj) for di, dj in offsets]

--- a/src/mazemastery/renderer.py
+++ b/src/mazemastery/renderer.py
@@ -1,12 +1,16 @@
-import tkinter as tk
-import random
 import math
+import os
+import random
+import tkinter as tk
+from typing import Dict, List, Tuple
+
+from PIL import Image, ImageTk  # type: ignore
+
+from mazemastery.debug_menu import DebugMenu
 from mazemastery.maze import get_maze_size
 from mazemastery.styles import Colors
-from mazemastery.debug_menu import DebugMenu
-from typing import List, Tuple, Dict
-from PIL import ImageTk, Image
-import os
+from mazemastery.types import ColorDict, Coord
+
 
 class GUI:
     def __init__(
@@ -14,9 +18,9 @@ class GUI:
         maze: Dict[Tuple[int, int], List[Tuple[int, int]]],
         minotaur_coords: Tuple[int, int],
         cell_size: int = 50,
-        grid_width: int = None,
-        gem_size: int = None,
-        minotaur_size: int = None,
+        grid_width: int | None = None,
+        gem_size: int | None = None,
+        minotaur_size: int | None = None,
         delay: int = 100,
         offset_rows: int = 2,
         offset_cols: int = 1,
@@ -48,7 +52,6 @@ class GUI:
         self.delay = delay
         self.m, self.n = get_maze_size(maze)
         self.initial_lives = initial_lives
-        self.sprites = {}
 
         # Derived sizes
         self.wall_width = self.cell_size // 10
@@ -70,8 +73,8 @@ class GUI:
 
         # Buffers tracking changes of state, such that we do not need to redraw
         # all items on every update_draw call.
-        self.blue_gem_buffer = set()
-        self.red_gem_buffer = set()
+        self.blue_gem_buffer: set[Coord] = set()
+        self.red_gem_buffer: set[Coord] = set()
         self.initial_pos = initial_pos
 
         # Canvas to draw on
@@ -89,11 +92,11 @@ class GUI:
         self.root.configure(bg=Colors.brown_highlight)
 
         # For sprites
-        self.sprites = {}
+        self.sprites: dict = {}
         self.sprite_path = os.path.join(os.path.dirname(__file__), os.path.join("sprites"))
         
 
-    def initial_draw(self):
+    def initial_draw(self) -> None:
         """
         Draws components of the maze that will remain unchanged throughout the
         game.
@@ -105,7 +108,7 @@ class GUI:
         self.draw_player(self.initial_pos, self.initial_pos)
         self.draw_initial_row_col_numbers()
 
-    def update_draw(self, old_pos, curr_pos, lives):
+    def update_draw(self, old_pos: Coord, curr_pos: Coord, lives: int) -> None:
         """
         Draws components of the maze that will change throughout the game.
         Should be called after every move. Will clear buffers.
@@ -119,8 +122,8 @@ class GUI:
         self.red_gem_buffer = set()
         self.blue_gem_buffer = set()
 
-    def draw_wall(self, start_x, start_y, end_x, end_y, wall_width, wall_color):
-        self.canvas.create_line(
+    def draw_wall(self, start_x: int, start_y: int, end_x: int, end_y: int, wall_width: int, wall_color: str) -> None:
+        self.canvas.create_line( # type: ignore
             start_x,
             start_y,
             end_x,
@@ -131,7 +134,7 @@ class GUI:
             capstyle=tk.ROUND,
         )
 
-    def draw_walls(self, wall_width, wall_color):
+    def draw_walls(self, wall_width: int, wall_color: str) -> None:
         for i in range(self.m):
             for j in range(self.n):
                 off_i = i + self.offset_rows
@@ -173,7 +176,7 @@ class GUI:
                         wall_color=wall_color,
                     )
 
-    def draw_wall_shadows(self):
+    def draw_wall_shadows(self) -> None:
         for i in range(self.m):
             for j in range(self.n):
                 off_i = i + self.offset_rows
@@ -192,7 +195,7 @@ class GUI:
                         right_x = (off_j + 1) * self.cell_size
                     else:
                         right_x = (off_j + 1) * self.cell_size + self.shadow_offset
-                    self.canvas.create_polygon(
+                    self.canvas.create_polygon( # type: ignore
                         left_x,
                         off_i * self.cell_size,
                         (off_j + 1) * self.cell_size,
@@ -222,7 +225,7 @@ class GUI:
                         bottom_y = (off_i + 1) * self.cell_size
                     else:
                         bottom_y = (off_i + 1) * self.cell_size + self.shadow_offset
-                    self.canvas.create_polygon(
+                    self.canvas.create_polygon( # type: ignore
                         off_j * self.cell_size,
                         top_y,
                         off_j * self.cell_size + self.shadow_offset,
@@ -237,11 +240,11 @@ class GUI:
                         tag="shadow",
                     )
 
-    def draw_grid(self):
+    def draw_grid(self) -> None:
 
         # Horizontal lines
         for i in range(self.offset_rows, self.m + self.offset_rows):
-            self.canvas.create_line(
+            self.canvas.create_line( # type: ignore
                 self.offset_cols + self.cell_size,
                 i * self.cell_size,
                 (self.n + self.offset_cols) * self.cell_size,
@@ -253,7 +256,7 @@ class GUI:
         
         # Vertical lines
         for j in range(self.n + self.offset_cols):
-            self.canvas.create_line(
+            self.canvas.create_line( # type: ignore
                 j * self.cell_size,
                 self.offset_rows * self.cell_size,
                 j * self.cell_size,
@@ -263,7 +266,7 @@ class GUI:
                 tag="grid",
             )
 
-    def draw_gem(self, pos, gem_size, color):
+    def draw_gem(self, pos: Coord, gem_size: int, color: ColorDict) -> None:
         """
         Draws a fancy gem at in the cell (i, j).
         """
@@ -394,7 +397,7 @@ class GUI:
             width=2,
         )
 
-    def draw_grass_blades(self, pos, num_grass=3, num_blades=4):
+    def draw_grass_blades(self, pos: Coord, num_grass: int=3, num_blades: int=4) -> None:
         """
         Draws some weeds at a random position in the cell (i, j).
         """
@@ -443,7 +446,7 @@ class GUI:
                     - y
                 )
                 shadow_offset = min(shadow_offset_x, shadow_offset_y)
-                self.canvas.create_line(
+                self.canvas.create_line( # type: ignore
                     blade_x,
                     y,
                     # Make shadow offset proportional to blade height
@@ -454,7 +457,7 @@ class GUI:
                     tag="grass_blade",
                 )
 
-                self.canvas.create_rectangle(
+                self.canvas.create_rectangle( # type: ignore
                     blade_x,
                     y,
                     blade_x + blade_width,
@@ -465,7 +468,7 @@ class GUI:
                 )
 
                 # Small highlight
-                self.canvas.create_rectangle(
+                self.canvas.create_rectangle( # type: ignore
                     blade_x,
                     y - blade_height + blade_width,
                     blade_x + blade_width,
@@ -475,7 +478,7 @@ class GUI:
                     tag="grass_blade",
                 )
 
-    def draw_grass(self):
+    def draw_grass(self) -> None:
         """
         Instead of rendering empty cells with four walls in case a cell is not
         connnected to the maze, we render it as a path of grass.
@@ -486,7 +489,7 @@ class GUI:
                     continue
                 off_i = i + self.offset_rows
                 off_j = j + self.offset_cols
-                self.canvas.create_rectangle(
+                self.canvas.create_rectangle( # type: ignore
                     off_j * self.cell_size,
                     off_i * self.cell_size,
                     (off_j + 1) * self.cell_size,
@@ -500,7 +503,7 @@ class GUI:
                 if self.maze[(i, j)] == []:
                     self.draw_grass_blades((i, j))
 
-    def draw_maze(self):
+    def draw_maze(self) -> None:
         """
         Render a maze using tkinter.
         """
@@ -536,7 +539,7 @@ class GUI:
         j += self.offset_cols
 
         # Shadow
-        self.canvas.create_oval(
+        self.canvas.create_oval( # type: ignore
             j * self.cell_size + self.cell_size // 3,
             i * self.cell_size + 2 * self.cell_size // 3,
             j * self.cell_size +  4 * self.cell_size // 5,
@@ -558,7 +561,7 @@ class GUI:
 
         self.draw_sprite(file_name, self.cell_size, i, j, "player", use_offset=False, dy=-self.cell_size // 4)
 
-    def draw_pebble(self, pos):
+    def draw_pebble(self, pos: Coord) -> None:
         i, j = pos
         x = random.randint(j * self.cell_size, (j + 1) * self.cell_size)
         y = random.randint(i * self.cell_size, (i + 1) * self.cell_size)
@@ -569,7 +572,7 @@ class GUI:
         size = random.randint(min_size, max_size)
 
         # Base
-        self.canvas.create_rectangle(
+        self.canvas.create_rectangle( # type: ignore
             x,
             y,
             x + size,
@@ -580,7 +583,7 @@ class GUI:
         )
 
         # Highlight
-        self.canvas.create_rectangle(
+        self.canvas.create_rectangle( # type: ignore
             x + 2,
             y + 2,
             x + size // 3 * 2,
@@ -590,7 +593,7 @@ class GUI:
             tag="cell",
         )
 
-    def draw_cells(self, cell_color, pebble_count=10):
+    def draw_cells(self, cell_color: str, pebble_count: int=10) -> None:
         """
         Render the cells using tkinter.
         """
@@ -598,7 +601,7 @@ class GUI:
             for j in range(self.n):
                 off_i = i + self.offset_rows
                 off_j = j + self.offset_cols
-                self.canvas.create_rectangle(
+                self.canvas.create_rectangle( # type: ignore
                     off_j * self.cell_size,
                     off_i * self.cell_size,
                     (off_j + 1) * self.cell_size,
@@ -611,7 +614,7 @@ class GUI:
                 for _ in range(pebble_count):
                     self.draw_pebble((off_i, off_j))
 
-    def draw_gems(self):
+    def draw_gems(self) -> None:
         """
         Render gems using tkinter.
         """
@@ -621,7 +624,7 @@ class GUI:
         for i, j in self.red_gem_buffer:
             self.draw_gem((i, j), self.cell_size // 2, Colors.reds)
 
-    def draw_minotaur(self):
+    def draw_minotaur(self) -> None:
         """
         Render minotaur using tkinter.
         """
@@ -642,8 +645,8 @@ class GUI:
 
         self.draw_sprite("minotaur.png", self.cell_size, i, j, "minotaur", use_offset=False, dy=-self.cell_size // 4)
 
-    def draw_path_segment(self, source, target):
-        self.canvas.create_line(
+    def draw_path_segment(self, source: Coord, target: Coord) -> None:
+        self.canvas.create_line( # type: ignore
             (source[1] + self.offset_cols) * self.cell_size + self.cell_size // 2,
             (source[0] + self.offset_rows) * self.cell_size + self.cell_size // 2,
             (target[1] + self.offset_cols) * self.cell_size + self.cell_size // 2,
@@ -653,11 +656,11 @@ class GUI:
             tag="path",
         )
 
-    def draw_initial_row_col_numbers(self, font_size=None):
+    def draw_initial_row_col_numbers(self, font_size: int | None=None) -> None:
         if font_size is None:
             font_size = self.cell_size // 4
         for i in range(self.m):
-            self.canvas.create_text(
+            self.canvas.create_text( # type: ignore
                 (self.offset_cols - 0.5) * self.cell_size,
                 (i + self.offset_rows + 0.5) * self.cell_size,
                 text=str(i),
@@ -667,7 +670,7 @@ class GUI:
                 tag=f"row_number_{i}",
             )
         for j in range(self.n):
-            self.canvas.create_text(
+            self.canvas.create_text( # type: ignore
                 (j + self.offset_cols + 0.5) * self.cell_size,
                 (self.offset_rows - 2 / 3) * self.cell_size,
                 text=str(j),
@@ -677,14 +680,14 @@ class GUI:
                 tag=f"col_number_{j}",
             )
 
-    def draw_row_col_numbers(self, old_pos, pos, font_size=None):
+    def draw_row_col_numbers(self, old_pos: Coord, pos: Coord, font_size: int | None=None) -> None:
         if font_size is None:
             font_size = self.cell_size // 4
         self.canvas.delete("number")  # delete old numbers
         if old_pos[0] != pos[0]:  # row number changed, update required
             self.canvas.delete(f"row_number_{old_pos[0]}")
             self.canvas.delete(f"row_number_{pos[0]}")
-            self.canvas.create_text(
+            self.canvas.create_text( # type: ignore
                 (self.offset_cols - 0.5) * self.cell_size,
                 (old_pos[0] + self.offset_rows + 0.5) * self.cell_size,
                 text=str(old_pos[0]),
@@ -693,7 +696,7 @@ class GUI:
                 anchor="e",
                 tag=f"row_number_{old_pos[0]}",
             )
-            self.canvas.create_text(
+            self.canvas.create_text( # type: ignore
                 (self.offset_cols - 0.5) * self.cell_size,
                 (pos[0] + self.offset_rows + 0.5) * self.cell_size,
                 text=str(pos[0]),
@@ -705,7 +708,7 @@ class GUI:
         if old_pos[1] != pos[1]:  # col number changed, update required
             self.canvas.delete(f"col_number_{old_pos[1]}")
             self.canvas.delete(f"col_number_{pos[1]}")
-            self.canvas.create_text(
+            self.canvas.create_text( # type: ignore
                 (old_pos[1] + self.offset_cols + 0.5) * self.cell_size,
                 (self.offset_rows - 2 / 3) * self.cell_size,
                 text=str(old_pos[1]),
@@ -714,7 +717,7 @@ class GUI:
                 anchor="n",
                 tag=f"col_number_{old_pos[1]}",
             )
-            self.canvas.create_text(
+            self.canvas.create_text( # type: ignore
                 (pos[1] + self.offset_cols + 0.5) * self.cell_size,
                 (self.offset_rows - 2 / 3) * self.cell_size,
                 text=str(pos[1]),
@@ -724,7 +727,7 @@ class GUI:
                 tag=f"col_number_{pos[1]}",
             )
     
-    def draw_hearts(self, num=5, filled=3, border_width=None, heart_size=None):
+    def draw_hearts(self, num: int=5, filled: int=3, border_width: int | None=None, heart_size: int | None=None) -> None:
         """
         Draws 'num' hearts, 'filled' of which are filled in. Hearts are placed
         on the first row of the canvas and grow from right to left.
@@ -764,13 +767,13 @@ class GUI:
 
     def draw_heart(
         self, 
-        x, 
-        y, 
-        size, 
-        highlight=False, 
-        highlight_color="white", 
-        color="red"
-    ):
+        x: int, 
+        y: int, 
+        size: int, 
+        highlight: bool=False, 
+        highlight_color: str="white", 
+        color: str="red"
+    ) -> None:
         """
         Draws a heart (vertical) whose tip is at (x, y). Size is the side
         length of the square that forms the bottom of the heart.
@@ -778,7 +781,7 @@ class GUI:
 
         # Tip
         cat = size / math.sqrt(2)
-        self.canvas.create_polygon(
+        self.canvas.create_polygon( # type: ignore
             x, y,
             x - cat, y - cat,
             x, y - 2 * cat,
@@ -792,7 +795,7 @@ class GUI:
         r = size / 2
         cx = x + cat / 2
         cy = y - 3 / 2 * cat
-        self.canvas.create_oval(
+        self.canvas.create_oval( # type: ignore
             cx - r, cy - r,
             cx + r, cy + r,
             fill=color,
@@ -803,7 +806,7 @@ class GUI:
         # Left part
         cx = x - cat / 2
         cy = y - 3 / 2 * cat
-        self.canvas.create_oval(
+        self.canvas.create_oval( # type: ignore
             cx - r, cy - r,
             cx + r, cy + r,
             fill=color,
@@ -815,7 +818,7 @@ class GUI:
         if not highlight:
             return
         
-        self.canvas.create_oval(
+        self.canvas.create_oval( # type: ignore
             cx - r / 2, cy - r / 2,
             cx + r / 2, cy + r / 2,
             fill=highlight_color,
@@ -823,7 +826,7 @@ class GUI:
             outline=""
         )
     
-    def draw_popup(self, text, color="black"):
+    def draw_popup(self, text: str, color: str="black") -> None:
         self.end_screen = tk.Label(
             text=text,
             font="Arial 100 bold",
@@ -840,13 +843,13 @@ class GUI:
             column=0,
             rowspan=len(self.debug_menu.api_buttons) + len(self.debug_menu.state_labels) + self.offset_rows + 2 + 2)
     
-    def draw_cloud(self, pos, cloud_color=Colors.cloud):
+    def draw_cloud(self, pos: Coord, cloud_color: str=Colors.cloud) -> None:
         """
         Draws cloud surround the whole maze except a window around the player.
         """
         self.canvas.delete("cloud")
         # Left side
-        self.canvas.create_rectangle(
+        self.canvas.create_rectangle( # type: ignore
             self.cell_size * self.offset_cols,
             self.cell_size,
             self.cell_size * self.offset_cols + self.cell_size * max(0, pos[1] - 1),
@@ -857,7 +860,7 @@ class GUI:
         )
 
         # Right side
-        self.canvas.create_rectangle(
+        self.canvas.create_rectangle( # type: ignore
             self.cell_size * self.offset_cols + self.cell_size * min(self.n, pos[1] + 2),
             self.cell_size,
             self.cell_size * self.offset_cols + self.cell_size * self.n,
@@ -868,7 +871,7 @@ class GUI:
         )
 
         # Top
-        self.canvas.create_rectangle(
+        self.canvas.create_rectangle( # type: ignore
             self.cell_size * self.offset_cols + self.cell_size * max(0, pos[1] - 1),
             self.cell_size,
             self.cell_size * self.offset_cols + self.cell_size * min(self.n, pos[1] + 2),
@@ -879,7 +882,7 @@ class GUI:
         )
 
         # Bottom
-        self.canvas.create_rectangle(
+        self.canvas.create_rectangle( # type: ignore
             self.cell_size * self.offset_cols + self.cell_size * max(0, pos[1] - 1),
             self.cell_size * self.offset_rows + self.cell_size * min(self.m, pos[0] + 2),
             self.cell_size * self.offset_cols + self.cell_size * min(self.n, pos[1] + 2),
@@ -951,7 +954,7 @@ class GUI:
         self.draw_sprite("cloud_nw_inner_corner_w.png", self.cell_size, i - 1, j - 2, "cloud")
         self.draw_sprite("cloud_nw_inner_corner_n.png", self.cell_size, i - 2, j - 1, "cloud")
 
-    def draw_sprite(self, name, size, i, j, tag, unique_id=None, use_offset=True, dx= 0, dy=0):
+    def draw_sprite(self, name: str, size: int, i: int, j: int, tag: str, unique_id: str | None=None, use_offset: bool=True, dx: int=0, dy: int=0) -> None:
         """
         Draws a sprite at position pos.
         """
@@ -971,8 +974,8 @@ class GUI:
             tag=tag
         )
 
-    def push_blue_gem_buffer(self, pos):
+    def push_blue_gem_buffer(self, pos: Coord) -> None:
         self.blue_gem_buffer.add(pos)
 
-    def push_red_gem_buffer(self, pos):
+    def push_red_gem_buffer(self, pos: Coord) -> None:
         self.red_gem_buffer.add(pos)

--- a/src/mazemastery/state.py
+++ b/src/mazemastery/state.py
@@ -1,3 +1,8 @@
+from typing import Any
+
+from mazemastery.types import Coord, Maze, Renderer
+
+
 class State:
     """
     State is a singleton class that holds the current state of the maze solver,
@@ -11,23 +16,30 @@ class State:
 
     _self = None
 
+    # Type declarations where mypy can't figure it out on its own
+    __maze: Maze
+    __renderer: Renderer
+    __minotaur_coords: Coord
+
     def __new__(
         cls,
-        maze=None,
-        renderer=None,
-        start_pos=(0, 0),
-        minotaur_coords=(0, 0),
-        blue_gem_coords=[],
-        red_gem_coords=[],
-        stack=[],
-        found=False,
-        initial_lives=5,
-        dead=False,
-        level=1,
-        *args,
-        **kwargs,
-    ):
+        maze: Maze | None=None,
+        renderer: Renderer | None=None,
+        start_pos: Coord=(0, 0),
+        minotaur_coords: Coord=(0, 0),
+        blue_gem_coords: list[Coord]=[],
+        red_gem_coords: list[Coord]=[],
+        stack: list[Coord]=[],
+        found: bool=False,
+        initial_lives: int=5,
+        dead: bool=False,
+        level: int=1,
+        *args: Any,
+        **kwargs: Any,
+    ) -> "State":
         if cls._self is None:
+            if maze is None or renderer is None:
+                raise RuntimeError("First state must be initialized with a maze and a renderer")
             cls._self = super(State, cls).__new__(cls, *args, **kwargs)
             cls._self.__maze = maze
             cls._self.__renderer = renderer
@@ -45,102 +57,102 @@ class State:
 
     def __init__(
         self,
-        maze=None,
-        renderer=None,
-        start_pos=(0, 0),
-        minotaur_coords=(0, 0),
-        blue_gem_coords=[],
-        red_gem_coords=[],
-        stack=[],
-        found=False,
-        lives=5,
-        dead=False,
-        level=1,
-        *args,
-        **kwargs,
+        maze: Maze | None=None,
+        renderer: Renderer | None=None,
+        start_pos: Coord=(0, 0),
+        minotaur_coords: Coord=(0, 0),
+        blue_gem_coords: list[Coord]=[],
+        red_gem_coords: list[Coord]=[],
+        stack: list[Coord]=[],
+        found: bool=False,
+        initial_lives: int=5,
+        dead: bool=False,
+        level: int=1,
+        *args: Any,
+        **kwargs: Any,
     ):
         super().__init__(*args, **kwargs)
 
     @property
-    def maze(self):
+    def maze(self) -> Maze:
         return self.__maze
 
     @property
-    def renderer(self):
+    def renderer(self) -> Renderer:
         return self.__renderer
 
     @property
-    def pos(self):
+    def pos(self) -> Coord:
         return self.__pos
 
     @pos.setter
-    def pos(self, new):
+    def pos(self, new: Coord) -> None:
         self.__pos = new
 
     @property
-    def minotaur_coords(self):
+    def minotaur_coords(self) -> Coord:
         return self.__minotaur_coords
 
     @property
-    def blue_gem_coords(self):
+    def blue_gem_coords(self) -> list[Coord]:
         return self.__blue_gem_coords
 
     @blue_gem_coords.setter
-    def blue_gem_coords(self, new):
+    def blue_gem_coords(self, new: list[Coord]) -> None:
         self.__blue_gem_coords = new
 
     @property
-    def red_gem_coords(self):
+    def red_gem_coords(self) -> list[Coord]:
         return self.__red_gem_coords
 
     @red_gem_coords.setter
-    def red_gem_coords(self, new):
+    def red_gem_coords(self, new: list[Coord]) -> None:
         self.__red_gem_coords = new
 
     @property
-    def stack(self):
+    def stack(self) -> list[Coord]:
         return self.__stack
 
     @stack.setter
-    def stack(self, new):
+    def stack(self, new: list[Coord]) -> None:
         self.__stack = new
 
     @property
-    def found(self):
+    def found(self) -> bool:
         return self.__found
 
     @found.setter
-    def found(self, new):
+    def found(self, new: bool) -> None:
         self.__found = new
 
     @property
-    def lives(self):
+    def lives(self) -> int:
         return self.__lives
 
     @lives.setter
-    def lives(self, new):
+    def lives(self, new: int) -> None:
         self.__lives = new
 
     @property
-    def initial_lives(self):
+    def initial_lives(self) -> int:
         return self.__initial_lives
 
     @initial_lives.setter
-    def initial_lives(self, new):
+    def initial_lives(self, new: int) -> None:
         self.__initial_lives = new
 
     @property
-    def dead(self):
+    def dead(self) -> bool:
         return self.__dead
 
     @dead.setter
-    def dead(self, new):
+    def dead(self, new: bool) -> None:
         self.__dead = new
 
     @property
-    def level(self):
+    def level(self) -> int:
         return self.__level
     
     @level.setter
-    def level(self, new):
+    def level(self, new: int) -> None:
         self.__level = new

--- a/src/mazemastery/styles.py
+++ b/src/mazemastery/styles.py
@@ -1,5 +1,7 @@
 import tkinter as tk
 
+from mazemastery.types import ColorDict
+
 
 class Colors:
     green_base = "#4b9a49"
@@ -10,7 +12,7 @@ class Colors:
     brown_highlight = "#b4a993"
     brown_border = "#544d3b"
     cloud = "#eff4f5"
-    blues = {
+    blues: ColorDict = {
         0: "#0069aa",
         1: "#0098dc",
         2: "#00cdf9",
@@ -18,7 +20,7 @@ class Colors:
         4: "#ffffff",
         "main": "#0cf1ff",
     }
-    reds = {
+    reds: ColorDict = {
         -1: "#421a1e",
         0: "#9d2231",
         1: "#e12937",
@@ -31,7 +33,7 @@ class Colors:
 
 class Styles:
     @staticmethod
-    def active_button_style(cell_size):
+    def active_button_style(cell_size: int) -> dict:
         return {
             "font": f"Courier {cell_size // 4}",
             "height": 1,
@@ -48,7 +50,7 @@ class Styles:
         }
 
     @staticmethod
-    def nav_button_style(cell_size):
+    def nav_button_style(cell_size: int) -> dict:
         return {
             "font": f"Courier {cell_size // 4}",
             "height": 1,
@@ -61,7 +63,7 @@ class Styles:
         }
 
     @staticmethod
-    def label_style(cell_size):
+    def label_style(cell_size: int) -> dict:
         return {
             "font": f"Courier {cell_size // 4}",
             "height": 1,
@@ -72,7 +74,7 @@ class Styles:
         }
 
     @staticmethod
-    def debug_button_style(cell_size):
+    def debug_button_style(cell_size: int) -> dict:
         return {
             "font": f"Arial {cell_size // 4}",
             "height": 1,

--- a/src/mazemastery/types.py
+++ b/src/mazemastery/types.py
@@ -1,0 +1,12 @@
+from typing import TYPE_CHECKING, Literal
+
+Coord = tuple[int, int]
+Maze = dict[Coord, list[Coord]]
+ColorDict = dict[int | Literal["main"], str]
+
+# This avoid circular imports.
+# See https://docs.python.org/3/library/typing.html#typing.TYPE_CHECKING
+if TYPE_CHECKING:
+    from mazemastery.renderer import GUI as Renderer
+else:
+    Renderer = object


### PR DESCRIPTION
This adds types, as discussed per email with you guys.

My formatter may have reordered some imports.

To avoid circular dependency imports at runtime, I've used the `TYPE_CHECKING` flag to define types more generically (e.g. as `object`) on runtime.

Looks like all the TkInter calls are typed are requiring `str` params. Non-string params are no problems at runtime, though. I have thus not touched this and just added `# type: ignore` on those lines where mypy was still complaining.

I haven't used the new type alias construct in Python 3.12 but I did use the lowercase types of 3.9 (e.g. `list[int]` instead of `List[int]` with an import).

I haven't touched the `student_solutions.py` file.